### PR TITLE
add required option for dev CD

### DIFF
--- a/config/ips/manager_patch.yaml
+++ b/config/ips/manager_patch.yaml
@@ -1,5 +1,5 @@
 
-# Make image pull policy always
+# Make image pull policy always -- dev deploy requires this
 - op: add
   path: /spec/template/spec/containers/0/imagePullPolicy
   value: Always
@@ -8,4 +8,8 @@
 - op: add
   path: /spec/template/spec/imagePullSecrets
   value: 
-  - name: quay-secret
+  - name: quay-secret-llm-d
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --epp-cluster-role=epp-cluster-role


### PR DESCRIPTION
`--epp-cluster-role` is now a required option to the manager.  Set with a default for CD in dev environment.