### PR TITLE
fix: manager clusterrole missing get/list/watch on `pods` and `endpointslices`

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -20,6 +20,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - create
@@ -47,6 +55,14 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - inference.networking.x-k8s.io
   resources:

--- a/internal/controller/modelservice_controller.go
+++ b/internal/controller/modelservice_controller.go
@@ -138,6 +138,8 @@ func (t *TemplateVars) from(ctx context.Context, msvc *msv1alpha1.ModelService) 
 // +kubebuilder:rbac:groups="",resources=services,verbs=list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups="discovery.k8s.io",resources=endpointslices,verbs=get;list;watch
 
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.20.4/pkg/reconcile


### PR DESCRIPTION
The manager cluster role seems to be missing permissions for `pods` and `endpointslices`. Otherwise I'm getting:

```
{"level":"error","ts":"2025-05-08T10:39:47.439583233Z","caller":"controller/child_resources.go:999","msg":"unable to create epp rolebinding from immutable base configmap ","controller":"modelservice","controllerGroup":"llm-d.ai","controllerKind":"ModelService","ModelService":{"name":"vllm-sim-model-service","namespace":"llm-d"},"namespace":"llm-d","name":"vllm-sim-model-service","reconcileID":"e5f9e87e-5b05-404a-bcd3-2ec8e24525c0","error":"rolebindings.rbac.authorization.k8s.io \"vllm-sim-model-service-epp-rolebinding\" is forbidden: user \"system:serviceaccount:llm-d:llm-d-llm-d-modelservice\" (groups=[\"system:serviceaccounts\" \"system:serviceaccounts:llm-d\" \"system:authenticated\"]) is attempting to grant RBAC permissions not currently held:\n{APIGroups:[\"\"], Resources:[\"pods\"], Verbs:[\"get\" \"watch\" \"list\"]}\n{APIGroups:[\"discovery.k8s.io\"], Resources:[\"endpointslices\"], Verbs:[\"get\" \"watch\" \"list\"]}","stacktrace":"github.com/neuralmagic/llm-d-model-service/internal/controller.(*BaseConfig).createEppRoleBinding\n\t/workspace/internal/controller/child_resources.go:999\ngithub.com/neuralmagic/llm-d-model-service/internal/controller.(*BaseConfig).createOrUpdate\n\t/workspace/internal/controller/child_resources.go:606\ngithub.com/neuralmagic/llm-d-model-service/internal/controller.(*ModelServiceReconciler).Reconcile\n\t/workspace/internal/controller/modelservice_controller.go:177\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:119\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:334\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255"}
{"level":"error","ts":"2025-05-08T10:39:47.43962524Z","caller":"controller/child_resources.go:608","msg":"unable to create epp service account","controller":"modelservice","controllerGroup":"llm-d.ai","controllerKind":"ModelService","ModelService":{"name":"vllm-sim-model-service","namespace":"llm-d"},"namespace":"llm-d","name":"vllm-sim-model-service","reconcileID":"e5f9e87e-5b05-404a-bcd3-2ec8e24525c0","error":"rolebindings.rbac.authorization.k8s.io \"vllm-sim-model-service-epp-rolebinding\" is forbidden: user \"system:serviceaccount:llm-d:llm-d-llm-d-modelservice\" (groups=[\"system:serviceaccounts\" \"system:serviceaccounts:llm-d\" \"system:authenticated\"]) is attempting to grant RBAC permissions not currently held:\n{APIGroups:[\"\"], Resources:[\"pods\"], Verbs:[\"get\" \"watch\" \"list\"]}\n{APIGroups:[\"discovery.k8s.io\"], Resources:[\"endpointslices\"], Verbs:[\"get\" \"watch\" \"list\"]}","stacktrace":"github.com/neuralmagic/llm-d-model-service/internal/controller.(*BaseConfig).createOrUpdate\n\t/workspace/internal/controller/child_resources.go:608\ngithub.com/neuralmagic/llm-d-model-service/internal/controller.(*ModelServiceReconciler).Reconcile\n\t/workspace/internal/controller/modelservice_controller.go:177\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:119\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:334\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255"}
```