### PR TITLE
Reset replicas with scaling decoupled

### DIFF
--- a/internal/controller/modelservice_controller.go
+++ b/internal/controller/modelservice_controller.go
@@ -187,13 +187,8 @@ func (r *ModelServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// TODO: Post-process for decoupled Scaling
 	log.FromContext(ctx).V(1).Info("attempting to createOrUpdate child resources")
-	if modelService.Spec.DecoupleScaling {
-		log.FromContext(ctx).V(1).Info("scaling is decoupled, resetting prefill and decode replicas to 1")
-		resetReplicas := int32(1)
-		interpolatedBaseConfig.DecodeDeployment.Spec.Replicas = &resetReplicas
-		interpolatedBaseConfig.PrefillDeployment.Spec.Replicas = &resetReplicas
-	}
-	err = interpolatedBaseConfig.createOrUpdate(ctx, r)
+
+	err = interpolatedBaseConfig.createOrUpdate(ctx, r, modelService.Spec.DecoupleScaling)
 
 	if err != nil {
 		log.FromContext(ctx).Error(err, "unable createorupdate from interpolatedBaseConfig")


### PR DESCRIPTION
Replicas can only start with an arbitrary value when scaling is decoupled in the MSVC spec. Fixes #127 