### PR TITLE
allow image pull secrets

### DIFF
--- a/config/summitdemo/manager_patch.yaml
+++ b/config/summitdemo/manager_patch.yaml
@@ -10,9 +10,9 @@
   - name: $IMAGE_PULL_SECRET
 
 # to configure pull secrets for pd and epp pods, uncomment
-# - op: add
-#   path: /spec/template/spec/containers/0/args/-
-#   value: --pd-pull-secrets=$PD_PULL_SECRETS
-# - op: add
-#   path: /spec/template/spec/containers/0/args/-
-#   value: --epp-pull-secrets=$EPP_PULL_SECRETS
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --pd-pull-secrets=$PD_PULL_SECRETS
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --epp-pull-secrets=$EPP_PULL_SECRETS


### PR DESCRIPTION
Update summitdemo overlay to avoid image pull secrets in the modelservice and base config.