### PR TITLE
Ensure PR checks run only before merge and not after

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -1,9 +1,6 @@
 name: CI - PR Checks
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Improvements to CI.