### PR TITLE
Modify e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ DEV_VERSION ?= 0.0.1
 PROD_VERSION ?= 0.0.0
 IMAGE_TAG_BASE ?= ghcr.io/llm-d/$(PROJECT_NAME)
 IMG = $(IMAGE_TAG_BASE):$(DEV_VERSION)
+IMG_ARCHIVE ?= /tmp/image.tar
 IMAGE_PULL_SECRET ?= quay-secret-llm-d
 NAMESPACE ?= hc4ai-operator
 LOG_LEVEL ?= info
@@ -120,6 +121,10 @@ run: manifests generate fmt vet ## Run a controller from your host.
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
 	$(CONTAINER_TOOL) build -t ${IMG} .
+
+.PHONY: archive-image
+archive-image: ## Save docker image as tar file
+	$(CONTAINER_TOOL) save -o ${IMG_ARCHIVE} ${IMG}
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet setup-envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... -v IMAGE_PULL_POLICY=Never) -coverprofile cover.out
 
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet setup-envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... -v IMAGE_PULL_POLICY=Never) -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./...)  -v IMAGE_PULL_POLICY=Never -coverprofile cover.out
 
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.

--- a/config/dev/manager_patch.yaml
+++ b/config/dev/manager_patch.yaml
@@ -17,3 +17,8 @@
 - op: add
   path: /spec/template/spec/containers/0/args/-
   value: --epp-pull-secrets=$EPP_PULL_SECRETS
+
+# Make image pull policy configurable -- e.g., Always, Never, IfNotPresent
+- op: add
+  path: /spec/template/spec/containers/0/imagePullPolicy
+  value: ${IMAGE_PULL_POLICY}

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: llm-d.ai/modelservice
-  newTag: v0.0.1
+  newName: ghcr.io/llm-d/llm-d-model-service
+  newTag: 0.0.1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: ghcr.io/llm-d/llm-d-model-service
-  newTag: 0.0.1
+  newName: llm-d.ai/modelservice
+  newTag: v0.0.1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -67,6 +67,7 @@ spec:
           - --log-level=$LOG_LEVEL
           - --epp-cluster-role=$EPP_CLUSTER_ROLE
         image: controller:latest
+        imagePullPolicy: Always
         name: manager
         ports: []
         securityContext:

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -125,4 +125,9 @@ var _ = AfterSuite(func() {
 		_, _ = fmt.Fprintf(GinkgoWriter, "Uninstalling CertManager...\n")
 		utils.UninstallCertManager()
 	}
+
+	// delete test cluster
+	cmd := exec.Command("kind", "delete", "cluster", "--name", testCluster)
+	_, _ = utils.Run(cmd)
+
 })

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -34,6 +34,7 @@ var (
 	// projectImage is the name of the image which will be build and loaded
 	// with the code source changes to be tested.
 	projectImage = "llm-d.ai/modelservice:v0.0.1"
+	imageArchive = "/tmp/llm-d.ai-modelservice-v0.0.1.tar"
 )
 
 // TestE2E runs the end-to-end (e2e) test suite for the project. These tests execute in an isolated,
@@ -88,10 +89,15 @@ var _ = BeforeSuite(func() {
 	_, err = utils.Run(cmd)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the manager(Operator) image")
 
+	By("archiving the image")
+	cmd = exec.Command("make", "archive-image", fmt.Sprintf("IMG=%s", projectImage), fmt.Sprintf("IMG_ARCHIVE=%s", imageArchive))
+	_, err = utils.Run(cmd)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to archive the manager(operator) image")
+
 	// TODO(user): If you want to change the e2e test vendor from Kind, ensure the image is
 	// built and available before running the tests. Also, remove the following block.
 	By("loading the manager(Operator) image on Kind")
-	err = utils.LoadImageToKindClusterWithName(projectImage)
+	err = utils.LoadImageToKindClusterWithName(imageArchive)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the manager(Operator) image into Kind")
 
 	// The tests-e2e are intended to run on a temporary cluster that is created and destroyed for testing.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -11,7 +12,15 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	msv1alpha1 "github.com/llm-d/llm-d-model-service/api/v1alpha1"
 	"github.com/llm-d/llm-d-model-service/test/utils"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	giev1alpha2 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha2"
+	"sigs.k8s.io/yaml"
 )
 
 // namespace where the project is deployed in
@@ -26,6 +35,118 @@ const metricsServiceName = "modelservice-controller-manager-metrics-service"
 // metricsRoleBindingName is the name of the RBAC that will be created to allow get the metrics data
 const metricsRoleBindingName = "modelservice-metrics-binding"
 
+const (
+	modelServiceName    = "llama-3-1-8b-instruct"
+	decodeWorkloadName  = "llama-3-1-8b-instruct-decode"
+	prefillWorkloadName = "llama-3-1-8b-instruct-prefill"
+)
+
+const configMapYAML = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: basic-base-conf
+data:
+  configMaps: |
+    - metadata:
+        name: cm1
+      data: 
+        key1: value1
+        key2: value2
+    - metadata:
+        name: cm2
+      data:
+        key3: value3
+        key4: value4
+  decodeDeployment: |
+    spec:
+      replicas: 2
+      template:
+        spec:
+          containers:
+          - name: llm
+            command:
+            - sleep
+  decodeService: |
+    spec:
+      selector:
+        app.kubernetes.io/name: decodeServiceLabelInBaseConfig
+      ports:
+        - protocol: TCP
+          port: 80
+          targetPort: 9376
+  prefillDeployment: |
+    spec:
+      replicas: 2
+      template:
+        spec:
+          containers:
+          - name: llm
+            command:
+            - sleep
+  prefillService: |
+    spec:
+      selector:
+        app.kubernetes.io/name: prefillServiceLabelInBaseConfig
+      ports:
+        - protocol: TCP
+          port: 80
+          targetPort: 9376
+  inferenceModel: |
+    spec:
+      criticality: Standard    
+  inferencePool: |
+    spec:
+      targetPortNumber: 9376
+  eppDeployment: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: epp
+      namespace: default
+    spec:
+      replicas: 1
+      template:
+        spec:
+          terminationGracePeriodSeconds: 130
+          containers:
+          - name: epp
+            image: busybox
+            ports:
+            - containerPort: 9002
+            - containerPort: 9003
+            - name: metrics
+              containerPort: 9090
+            livenessProbe:
+              grpc:
+                port: 9003
+                service: inference-extension
+              initialDelaySeconds: 5
+              periodSeconds: 10
+            readinessProbe:
+              grpc:
+                port: 9003
+                service: inference-extension
+              initialDelaySeconds: 5
+              periodSeconds: 10 
+  eppService: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: llm-llama3-8b-instruct-epp
+      namespace: default
+    spec:
+      selector:
+        app: llm-llama3-8b-instruct-epp
+      ports:
+      - protocol: TCP
+        port: 9002
+        targetPort: 9002
+        appProtocol: http2
+    type: ClusterIP
+`
+
+var imageName = "ghcr.io/linuxserver/nginx:1.26.3-r0-ls319"
 var _ = Describe("Manager", Ordered, func() {
 	var controllerPodName string
 
@@ -49,8 +170,22 @@ var _ = Describe("Manager", Ordered, func() {
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
 
+		By("installing external CRDs")
+
+		cmd = exec.Command("kubectl", "apply", "-f",
+			"https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/v0.3.0/manifests.yaml")
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
+
+		By("installing rolebinding for Epp")
+
+		cmd = exec.Command("kubectl", "apply", "-f",
+			"https://raw.githubusercontent.com/llm-d/gateway-api-inference-extension/refs/heads/dev/config/manifests/inferencepool-resources.yaml")
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to install rolebinding for Epp")
+
 		By("deploying the controller-manager")
-		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage))
+		cmd = exec.Command("make", "dev-deploy", fmt.Sprintf("IMG=%s", projectImage), fmt.Sprintf("EPP_CLUSTERROLE=%s", "pod-read"), fmt.Sprintf("IMAGE_PULL_POLICY=%s", "Never"))
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
 	})
@@ -187,7 +322,7 @@ var _ = Describe("Manager", Ordered, func() {
 				cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", namespace)
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(ContainSubstring("controller-runtime.metrics\tServing metrics server"),
+				g.Expect(output).To(ContainSubstring("Serving metrics server"),
 					"Metrics server not yet started")
 			}
 			Eventually(verifyMetricsServerStarted).Should(Succeed())
@@ -242,15 +377,117 @@ var _ = Describe("Manager", Ordered, func() {
 
 		// +kubebuilder:scaffold:e2e-webhooks-checks
 
-		// TODO: Customize the e2e test suite with scenarios specific to your project.
-		// Consider applying sample/CR(s) and check their status and/or verifying
-		// the reconciliation by using the metrics, i.e.:
-		// metricsOutput := getMetricsOutput()
-		// Expect(metricsOutput).To(ContainSubstring(
-		//    fmt.Sprintf(`controller_runtime_reconcile_total{controller="%s",result="success"} 1`,
-		//    strings.ToLower(<Kind>),
-		// ))
+		It("creates multiple ModelService resources using kubectl", func() {
+			By("Creating the basic base configmap")
+			var cm corev1.ConfigMap
+			err := yaml.Unmarshal([]byte(configMapYAML), &cm)
+			Expect(err).NotTo(HaveOccurred())
+
+			cm.Namespace = "default"
+
+			err = k8sClient.Create(ctx, &cm)
+			Expect(err).NotTo(HaveOccurred())
+
+			By(fmt.Sprintf("Creating ModelService %s", modelServiceName))
+
+			modelService := &msv1alpha1.ModelService{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: msv1alpha1.GroupVersion.String(),
+					Kind:       "ModelService",
+				}, ObjectMeta: metav1.ObjectMeta{
+					Name:      modelServiceName,
+					Namespace: namespace,
+				},
+				Spec: msv1alpha1.ModelServiceSpec{
+					ModelArtifacts: msv1alpha1.ModelArtifacts{
+						URI: "pvc://llama-pvc/path/to/model",
+					},
+					Routing: msv1alpha1.Routing{
+						ModelName: modelServiceName,
+					},
+					DecoupleScaling: false,
+					Decode: &msv1alpha1.PDSpec{
+						ModelServicePodSpec: msv1alpha1.ModelServicePodSpec{
+							Containers: []msv1alpha1.ContainerSpec{
+								{
+									Name:  "llm",
+									Image: &imageName,
+								},
+							},
+						},
+					},
+					Prefill: &msv1alpha1.PDSpec{
+						ModelServicePodSpec: msv1alpha1.ModelServicePodSpec{
+							Containers: []msv1alpha1.ContainerSpec{
+								{
+									Name:  "llm",
+									Image: &imageName,
+								},
+							},
+						},
+					},
+					BaseConfigMapRef: &corev1.ObjectReference{
+						Name:      "basic-base-conf",
+						Namespace: "default",
+					},
+				},
+			}
+
+			By(fmt.Sprintf("Creating ModelService %s", modelServiceName))
+			err = k8sClient.Create(context.TODO(), modelService)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Checking if Decode deployment was created")
+			var decode appsv1.Deployment
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: decodeWorkloadName, Namespace: namespace}, &decode)
+				return err == nil
+			}, time.Second*5, time.Millisecond*500).Should(BeTrue())
+
+			By("Checking if prefill deployment was created")
+			var prefill appsv1.Deployment
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: prefillWorkloadName, Namespace: namespace}, &prefill)
+				return err == nil
+			}, time.Second*5, time.Millisecond*500).Should(BeTrue())
+
+			By("Checking if a PD SA was created")
+			sa := corev1.ServiceAccount{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: modelServiceName + "-sa", Namespace: namespace}, &sa)
+				return err == nil
+			}, time.Second*5, time.Millisecond*500).Should(BeTrue())
+
+			By("Validating that the EPP ServiceAccount was created")
+			eppSA := corev1.ServiceAccount{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: modelServiceName + "-epp-sa", Namespace: namespace}, &eppSA)
+				return err == nil
+			}, time.Second*5, time.Millisecond*500).Should(BeTrue())
+
+			By("Checking if a epp RoleBinding was created")
+			rolebinding := rbacv1.RoleBinding{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: modelServiceName + "-epp-rolebinding", Namespace: namespace}, &rolebinding)
+				return err == nil
+			}, time.Second*5, time.Millisecond*500).Should(BeTrue())
+
+			By("Validating that the inferencepool was created")
+			infPool := giev1alpha2.InferencePool{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: modelServiceName + "-inference-pool", Namespace: namespace}, &infPool)
+				return err == nil
+			}, time.Second*5, time.Millisecond*500).Should(BeTrue())
+
+			By("Validating that the inferencemodel was created")
+			infModel := giev1alpha2.InferenceModel{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: modelServiceName, Namespace: namespace}, &infModel)
+				return err == nil
+			}, time.Second*5, time.Millisecond*500).Should(BeTrue())
+		})
 	})
+
 })
 
 // serviceAccountToken returns a token for the specified service account in the given namespace.

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -151,7 +151,6 @@ func IsCertManagerCRDsInstalled() bool {
 
 // LoadImageToKindClusterWithName loads a local docker image to the kind cluster
 func LoadImageToKindClusterWithName(imageName string, cluster string) error {
-	// cluster := "kind"
 	if v, ok := os.LookupEnv("KIND_CLUSTER"); ok {
 		cluster = v
 	}

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -155,7 +155,7 @@ func LoadImageToKindClusterWithName(name string) error {
 	if v, ok := os.LookupEnv("KIND_CLUSTER"); ok {
 		cluster = v
 	}
-	kindOptions := []string{"load", "docker-image", name, "--name", cluster}
+	kindOptions := []string{"load", "image-archive", name, "--name", cluster}
 	cmd := exec.Command("kind", kindOptions...)
 	_, err := Run(cmd)
 	return err

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -150,12 +150,12 @@ func IsCertManagerCRDsInstalled() bool {
 }
 
 // LoadImageToKindClusterWithName loads a local docker image to the kind cluster
-func LoadImageToKindClusterWithName(name string) error {
-	cluster := "kind"
+func LoadImageToKindClusterWithName(imageName string, cluster string) error {
+	// cluster := "kind"
 	if v, ok := os.LookupEnv("KIND_CLUSTER"); ok {
 		cluster = v
 	}
-	kindOptions := []string{"load", "image-archive", name, "--name", cluster}
+	kindOptions := []string{"load", "image-archive", imageName, "--name", cluster}
 	cmd := exec.Command("kind", kindOptions...)
 	_, err := Run(cmd)
 	return err


### PR DESCRIPTION
This is an extension to https://github.com/llm-d/llm-d-model-service/pull/199 that:
- by default uses cluster `kind-modelservice-test` instead of `kind`. This is to prevent conflict with manual tests.
- deletes the cluster and re-creates it before all tests
- deletes the cluster after all tests
- archives image as a tar file and load it using `archive-model` so that it works for podman
- includes this test in `make test`