### PR TITLE
Remove inf pool backendref creation

### DIFF
--- a/internal/controller/child_resources.go
+++ b/internal/controller/child_resources.go
@@ -854,9 +854,6 @@ func (childResources *BaseConfig) mergeHTTPRoute(ctx context.Context, msvc *msv1
 	// Get dest HTTPRoute
 	dest := *childResources.HTTPRoute
 
-	group := gatewayv1.Group("inference.networking.x-k8s.io")
-	kind := gatewayv1.Kind("InferencePool")
-
 	// At this point, we are going to create the desired HTTPRoute
 	// with the parentRefs supplied by the user and
 	// with InferencePool being a backendRef (we are adding this)
@@ -873,22 +870,6 @@ func (childResources *BaseConfig) mergeHTTPRoute(ctx context.Context, msvc *msv1
 		Spec: gatewayv1.HTTPRouteSpec{
 			CommonRouteSpec: gatewayv1.CommonRouteSpec{
 				ParentRefs: msvc.Spec.Routing.GatewayRefs,
-			},
-			Rules: []gatewayv1.HTTPRouteRule{
-				{
-					BackendRefs: []gatewayv1.HTTPBackendRef{
-						{
-							// InferencePool is added as a backendRef
-							BackendRef: gatewayv1.BackendRef{
-								BackendObjectReference: gatewayv1.BackendObjectReference{
-									Group: &group,
-									Kind:  &kind,
-									Name:  gatewayv1.ObjectName(infPoolName(msvc)),
-								},
-							},
-						},
-					},
-				},
 			},
 		},
 	}


### PR DESCRIPTION
The controller should not add InferencePool as a backendRef because the required port number (targetPortNumber) is unknown. The correct solution is to use mergo, but that's a bit tricky considering Rules can be many types. For now, just remove this feature and let the user configure HTTPRoute using template vars such as `{{ .InferencePoolName }}` and `getPort`.

